### PR TITLE
FIXUP wrong operator inversion in comparison

### DIFF
--- a/include/coat/asmjit/Ref.h
+++ b/include/coat/asmjit/Ref.h
@@ -59,10 +59,10 @@ struct Ref<::asmjit::x86::Compiler,T> {
 	// swap sides of operands and comparison, not needed for assembly, but avoids code duplication in wrapper
 	Condition<F> operator==(const T &other) const { return other==*this; }
 	Condition<F> operator!=(const T &other) const { return other!=*this; }
-	Condition<F> operator< (const T &other) const { return other>=*this; }
-	Condition<F> operator<=(const T &other) const { return other> *this; }
-	Condition<F> operator> (const T &other) const { return other<=*this; }
-	Condition<F> operator>=(const T &other) const { return other< *this; }
+	Condition<F> operator< (const T &other) const { return other> *this; }
+	Condition<F> operator<=(const T &other) const { return other>=*this; }
+	Condition<F> operator> (const T &other) const { return other< *this; }
+	Condition<F> operator>=(const T &other) const { return other<=*this; }
 	//TODO: possible without temporary: cmp m32 imm32, complicates Condition
 	Condition<F> operator==(int constant) const { T tmp(cc, "tmp"); tmp = *this; return tmp==constant; }
 	Condition<F> operator!=(int constant) const { T tmp(cc, "tmp"); tmp = *this; return tmp!=constant; }

--- a/include/coat/llvmjit/Ref.h
+++ b/include/coat/llvmjit/Ref.h
@@ -37,10 +37,10 @@ struct Ref<LLVMBuilders,T> {
 	// swap sides of operands and comparison, not needed for assembly, but avoids code duplication in wrapper
 	Condition<F> operator==(const T &other) const { return other==*this; }
 	Condition<F> operator!=(const T &other) const { return other!=*this; }
-	Condition<F> operator< (const T &other) const { return other>=*this; }
-	Condition<F> operator<=(const T &other) const { return other> *this; }
-	Condition<F> operator> (const T &other) const { return other<=*this; }
-	Condition<F> operator>=(const T &other) const { return other< *this; }
+	Condition<F> operator< (const T &other) const { return other> *this; }
+	Condition<F> operator<=(const T &other) const { return other>=*this; }
+	Condition<F> operator> (const T &other) const { return other< *this; }
+	Condition<F> operator>=(const T &other) const { return other<=*this; }
 	//TODO: possible without temporary: cmp m32 imm32, complicates Condition
 	Condition<F> operator==(int constant) const { T tmp(cc, "tmp"); tmp = *this; return tmp==constant; }
 	Condition<F> operator!=(int constant) const { T tmp(cc, "tmp"); tmp = *this; return tmp!=constant; }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the logic of comparison operators for `Ref<::asmjit::x86::Compiler>` and `Ref<LLVMBuilders, T>`, ensuring accurate comparison results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->